### PR TITLE
systemd: enable on TUN/TAP devices

### DIFF
--- a/systemd/ladvd.service
+++ b/systemd/ladvd.service
@@ -8,7 +8,7 @@ Requires=network.target
 After=network.target
 
 [Service]
-ExecStart=/usr/sbin/ladvd -f -a -z
+ExecStart=/usr/sbin/ladvd -f -t -a -z
 Restart=on-failure
 NoNewPrivileges=yes
 PrivateDevices=yes


### PR DESCRIPTION
This way KVM virtual machines become visible by default.