### PR TITLE
vxlan as tun interface and should be ignored for physical connectivity.

### DIFF
--- a/src/netif_linux.c
+++ b/src/netif_linux.c
@@ -123,7 +123,7 @@ static int netif_type(int sockfd, uint32_t index,
 	} else if (strcmp(dname, "802.1Q VLAN Support") == 0) {
 	    return(NETIF_VLAN);
 	// handle tun/tap
-	} else if (strcmp(dname, "tun") == 0 || strcmp(dname, "veth") == 0) {
+	} else if (strcmp(dname, "tun") == 0 || strcmp(dname, "veth") == 0 || strcmp(dname, "vxlan") == 0) {
 	    return(NETIF_TAP);
 	}
 


### PR DESCRIPTION
Hello. New technologies are here.
```# ladvdc -L
Capability Codes:
	r - Repeater, B - Bridge, H - Host, R - Router, S - Switch,
	W - WLAN Access Point, C - DOCSIS Device, T - Telephone, O - Other

Device ID                      Local Intf    Proto   Hold-time    Capability    Port ID
ed-8             eth3          LLDP    91           BR            Eth50
ed-7             eth1          LLDP    120          BR            Eth50
ed-8             eth2          LLDP    91           BR            Eth49
ed-7             eth0          LLDP    120          BR            Eth49
...
ed-19         vxlan-1670003 LLDP    150          BR            vxlan-16700038
ed-22         vxlan-1670009 LLDP    154          B             vxlan-16700098
ed-22         vxlan-1670023 LLDP    154          B             vxlan-16700236
ed-19         vxlan-1670016 LLDP    150          BR            vxlan-16700164
...
```

So vxlan interfaces are appeared in output and should be disabled for my point of view.

I thought to do it like 57a553566d457d85e61598881ef74c26fac7743c, but on other side - it's like VLAN and should be threated as  `NETIF_VLAN` or create new instance `NETIF_VXLAN`?
As from my side maybe it's like `NETIF_TAP` because it uses incapsulation...

Based on https://github.com/sspans/ladvd/issues/28